### PR TITLE
Spike: add Dredd hooks support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,11 @@ Dredd::Rack::RakeTask.new # run with `rake dredd`
 # Example of custom name and description
 namespace :blueprint do
   desc 'Verify an API complies with its blueprint'
-  Dredd::Rack::RakeTask.new(:verify)
+  dredd = Dredd::Rack::RakeTask.new(:verify)
+  runner =   Dredd::Rack::Runner.new ENV['API_HOST'] do |options|
+    options.hookfiles 'doc/hooks/hooks-worker-client.coffee'
+  end
+  dredd.instance_variable_set :@runner, runner
 end
 # run with `rake blueprint:verify`
 # see also `rake -T`

--- a/Rakefile
+++ b/Rakefile
@@ -5,15 +5,22 @@ require 'dredd/rack'
 Dredd::Rack.app = Dredd::Rack::Sinatra::Example
 Dredd::Rack::RakeTask.new # run with `rake dredd`
 
-# Example of custom name and description
-namespace :blueprint do
-  desc 'Verify an API complies with its blueprint'
-  dredd = Dredd::Rack::RakeTask.new(:verify)
-  runner =   Dredd::Rack::Runner.new ENV['API_HOST'] do |options|
-    options.hookfiles 'doc/hooks/hooks-worker-client.coffee'
+namespace :dredd do
+  namespace :hooks do
+    desc 'Try support for Dredd hooks written in Ruby (proof of concept)'
+    Dredd::Rack::RakeTask.new(:try) do |task|
+      task.runner.configure do |options|
+        options.hookfiles 'doc/hooks/hooks-worker-client.coffee'
+      end
+    end
   end
-  dredd.instance_variable_set :@runner, runner
 end
+
+namespace :blueprint do
+  desc 'Alias for dredd:hooks:try'
+  task :verify => 'dredd:hooks:try'
+end
+
 # run with `rake blueprint:verify`
 # see also `rake -T`
 

--- a/doc/hooks/dredd-worker.rb
+++ b/doc/hooks/dredd-worker.rb
@@ -1,0 +1,133 @@
+
+require 'socket'
+require 'json'
+
+HOST = '127.0.0.1'
+PORT = 61321
+MESSAGE_DELIMITER = "\n"
+
+@before_hooks = {}
+@after_hooks = {}
+
+def before transaction_name, &block
+  @before_hooks[transaction_name] = [] if @before_hooks[transaction_name].nil?
+  @before_hooks[transaction_name].push block
+end
+
+def after transaction_name, &block
+  @after_hooks[transaction_name] = [] if @after_hooks[transaction_name].nil?
+  @after_hooks[transaction_name].push block
+end
+
+def run_before_hooks_for_transaction transaction
+  transaction_name = transaction["name"]
+  hooks = @before_hooks[transaction_name]
+  if hooks.kind_of? Array
+    hooks.each do |hook_proc|
+      hook_proc.call transaction
+    end
+  end
+  return transaction
+end
+
+def run_after_hooks_for_transaction transaction
+  transaction_name = transaction["name"]
+  hooks = @after_hooks[transaction_name]
+  if hooks.kind_of? Array
+    hooks.each do |hook_proc|
+      hook_proc.call transaction
+    end
+  end
+  return transaction
+end
+
+def process_message message, client
+  event = message['event']
+  transaction = message['transaction']
+  if event == "before"
+    transaction = run_before_hooks_for_transaction transaction
+  end
+
+  if event == "after"
+    transaction = run_after_hooks_for_transaction transaction
+  end
+
+  to_send = {
+    "uuid" => message['uuid'],
+    "event" => event,
+    "transaction" => transaction
+  }.to_json
+  client.puts to_send + "\n"
+end
+
+def run_server
+  server = TCPServer.new HOST, PORT
+  loop do
+    #Thread.abort_on_exception=true
+    client = server.accept
+    STDERR.puts 'Dredd connected to Ruby Dredd hooks worker'
+    buffer = ""
+    while (data = client.recv(10))
+      buffer += data
+      if buffer.include? MESSAGE_DELIMITER
+        splitted_buffer = buffer.split(MESSAGE_DELIMITER)
+        buffer = ""
+
+        messages = []
+
+        splitted_buffer.each do |message|
+          begin
+            messages.push JSON.parse(message)
+
+          rescue JSON::ParserError
+            # if message aftger delimiter is not parseable json, it's
+            # a chunk of next message, put it back to the buffer
+            buffer += message
+          end
+        end
+
+        messages.each do |message|
+          process_message message, client
+        end
+      end
+    end
+    client.close
+  end
+end
+
+#
+# Register hooks here!
+#
+
+# If you want to pass output from ruby worker to Dredd report,
+# you have to use STDERR.puts. Puts to stdout is swalowed somewhere
+#
+
+# Tranasction object in the block is passed back to Dredd, so you can
+# modify it, save response to stash, or programatically fail the transaction
+# by setting trabsaction['fail'] to some message
+#
+# Let's inspect transaction object:
+#
+# STDERR.puts JSON.pretty_generate(transaction)
+
+stash = ""
+
+before ' > Hello, world! > Retrieve Message' do |transaction|
+  stash = 'stashed data'
+  STDERR.puts 'Before hook in Ruby'
+  transaction['fail'] = 'Yay! Failed in ruby hook.'
+end
+
+
+after ' > Hello, world! > Retrieve Message' do |transaction|
+   STDERR.puts 'After hook in Ruby'
+   STDERR.puts 'Stash content: ' + stash
+end
+
+
+# Run hooks server
+STDERR.puts 'Dredd Ruby hooks worker is running'
+
+run_server
+

--- a/doc/hooks/dredd-worker.rb
+++ b/doc/hooks/dredd-worker.rb
@@ -90,9 +90,28 @@ def run_server
           process_message message, client
         end
       end
+      ensure_the_ruby_process_gets_killed!
     end
+    STDERR.puts 'Closing socket...'
     client.close
   end
+end
+
+# Does actually ensure that the Ruby process gets killed
+#
+# I noticed that the Ruby process didn't get killed. As a
+# consequence, it was impossible to successfully run the rake task
+# twice. ("successfully" means: "Yay! Failed in ruby hook.")
+#
+# Do notice that the 'Closing socket...' message never gets printed.
+#
+# Printing 'anything' does in fact ensure the Ruby process gets killed,
+# even if it does not provoke the 'Closing socket...' print.
+# My understanding of sockets is insufficient to explain this result,
+# but that's what I've observed.
+#
+def ensure_the_ruby_process_gets_killed!
+  STDERR.puts 'anything' if buffer.empty?
 end
 
 #

--- a/doc/hooks/hooks-worker-client.coffee
+++ b/doc/hooks/hooks-worker-client.coffee
@@ -1,0 +1,129 @@
+hooks = require 'hooks'
+net = require 'net'
+EventEmitter = require('events').EventEmitter
+{exec} = require('child_process')
+
+HOOK_TIMEOUT = 5000
+WORKER_HOST = 'localhost'
+WORKER_PORT = 61321
+WORKER_MESSAGE_DELIMITER = "\n"
+WORKER_COMMAND = 'ruby ./doc/hooks/dredd-worker.rb'
+
+emitter = new EventEmitter
+
+hooks.beforeEach = (hookFn) ->
+  hooks.beforeAll (done) ->
+    for transactionKey, transaction of hooks.transactions or {}
+      hooks.beforeHooks[transaction.name] ?= []
+      hooks.beforeHooks[transaction.name].unshift hookFn
+    done()
+
+hooks.afterEach = (hookFn) ->
+  hooks.beforeAll (done) ->
+    for transactionKey, transaction of hooks.transactions or {}
+      hooks.afterHooks[transaction.name] ?= []
+      hooks.afterHooks[transaction.name].unshift hookFn
+    done()
+
+worker = exec WORKER_COMMAND
+console.log 'Spawning ruby worker'
+
+worker.stdout.on 'data', (data) ->
+  console.log data.toString()
+
+worker.stderr.on 'data', (data) ->
+  console.log data.toString()
+
+workerClient = net.connect port: WORKER_PORT, host: WORKER_HOST, () ->
+  # Do something when dredd starts
+  # message =
+  #   event: 'hooksInit'
+
+  # worker.write JSON.stringify message
+  # worker.write WORKER_MESSAGE_DELIMITER
+
+workerClient.on 'error', () ->
+  console.log 'Error connecting to the hook worker. Is the worker running?'
+  process.exit()
+
+workerBuffer = ""
+
+workerClient.on 'data', (data) ->
+  workerBuffer += data.toString()
+  if data.toString().indexOf(WORKER_MESSAGE_DELIMITER) > -1
+    splittedData = workerBuffer.split(WORKER_MESSAGE_DELIMITER)
+
+    # add last chunk to the buffer
+    workerBuffer = splittedData.pop()
+
+    messages = []
+    for message in splittedData
+      messages.push JSON.parse message
+
+    for message in messages
+      if message.uuid?
+        emitter.emit message.uuid, message
+      else
+        console.log 'UUID not present in message: ', JSON.stringify(message, null ,2)
+
+# Hack for blocking sleep, loading of hooks in dredd is not async
+# TODO Move connecting to worker to async beforeAll hook
+now = new Date().getTime()
+while new Date().getTime() < now + 1000
+  true
+
+hooks.beforeEach (transaction, callback) ->
+  # avoiding dependency on external module here.
+  uuid = Date.now().toString() + '-' + Math. random().toString(36).substring(7)
+
+  # send transaction to the worker
+  message =
+    event: 'before'
+    uuid: uuid
+    transaction: transaction
+
+  workerClient.write JSON.stringify message
+  workerClient.write WORKER_MESSAGE_DELIMITER
+
+  # set timeout for the hook
+  timeout = setTimeout () ->
+    transaction.fail = 'Hook timed out.'
+    callback()
+  , HOOK_TIMEOUT
+
+  # register event for the sent transaction
+  emitter.on uuid, (receivedMessage) ->
+    clearTimeout timeout
+    # workaround forassigning transacition
+    # this does not work:
+    # transaction = receivedMessage.transaction
+    for key, value of receivedMessage.transaction
+      transaction[key] = value
+    callback()
+
+hooks.afterEach (transaction, callback) ->
+  # avoiding dependency on external module here.
+  uuid = Date.now().toString() + '-' + Math. random().toString(36).substring(7)
+
+  # send transaction to the worker
+  message =
+    event: 'after'
+    uuid: uuid
+    transaction: transaction
+
+  workerClient.write JSON.stringify message
+  workerClient.write WORKER_MESSAGE_DELIMITER
+
+  timeout = setTimeout () ->
+    transaction.fail = 'Hook timed out.'
+    callback()
+  , HOOK_TIMEOUT
+
+  emitter.on uuid, (receivedMessage) ->
+    clearTimeout timeout
+    transacton = receivedMessage.transaction
+    callback()
+
+hooks.afterAll (callback) ->
+  worker.kill 'SIGKILL'
+  callback()


### PR DESCRIPTION
**Note**: the [`spike-add-dredd-hooks-support`](https://github.com/gonzalo-bulnes/dredd-rack-sinatra-example/tree/spike-add-dredd-hooks-support) branch is **experimental**. This PR was opened to hold the discussions around it. The result of these experiments will be integrated to [Dredd::Rack](https://github.com/gonzalo-bulnes/dredd-rack).

**As a** developer 
**In order to** be able to write Dredd hooks in Ruby 
**I want** a worker to be able to receive them from the Dredd process and send the results back 

See https://github.com/apiaryio/dredd/issues/134
